### PR TITLE
Fix update errors

### DIFF
--- a/config/coc-settings.json
+++ b/config/coc-settings.json
@@ -1,3 +1,4 @@
 {
-  "solargraph.diagnostics": true
+  "solargraph.diagnostics": true,
+  "coc.preferences.extensionUpdateCheck": "daily"
 }

--- a/config/init.vim
+++ b/config/init.vim
@@ -31,7 +31,6 @@ Plug 'scrooloose/nerdtree'
 Plug 'editorconfig/editorconfig-vim' " Per-project editor config
 Plug 'janko-m/vim-test'              " Test runner
 Plug 'tpope/vim-dadbod'              " Database client
-Plug 'tpope/vim-fugitive'            " Git wrapper
 call plug#end()
 
 syntax on

--- a/config/init.vim
+++ b/config/init.vim
@@ -31,6 +31,7 @@ Plug 'scrooloose/nerdtree'
 Plug 'editorconfig/editorconfig-vim' " Per-project editor config
 Plug 'janko-m/vim-test'              " Test runner
 Plug 'tpope/vim-dadbod'              " Database client
+Plug 'tpope/vim-fugitive'            " Git wrapper
 call plug#end()
 
 syntax on
@@ -62,7 +63,7 @@ let g:lightline =
   \       ['gitbranch', 'readonly', 'filename', 'modified']
   \     ]
   \   },
-  \   'component_function': { 'gitbranch': 'fugitive#head' }
+  \   'component_function': { 'gitbranch': 'FugitiveHead' }
   \ }
 let g:lightline.tabline = { 'left': [['buffers']], 'right': [['close']] }
 let g:lightline.component_expand = { 'buffers': 'lightline#bufferline#buffers' }


### PR DESCRIPTION
This fixes errors that get thrown when doing literally anything in my Vim setup. The old Lightline config was using deprecated Fugitive code so this updates it to use the new code.