### PR TITLE
feat: enable Kitty transparency

### DIFF
--- a/config/kitty.conf
+++ b/config/kitty.conf
@@ -1,4 +1,7 @@
 include ./theme.conf
 
+dynamic_background_opacity yes
+background_opacity 0.97
+
 font_family FuraMono Nerd Font
 font_size 13.0


### PR DESCRIPTION
# Overview

This makes it so that Kitty windows have transparency enabled by default. Just adding a little bit of spice.