### PR TITLE
fix: FiraMono Nerd Font reference

### DIFF
--- a/config/kitty.conf
+++ b/config/kitty.conf
@@ -3,5 +3,5 @@ include ./theme.conf
 dynamic_background_opacity yes
 background_opacity 0.97
 
-font_family FuraMono Nerd Font
+font_family FiraMono Nerd Font
 font_size 13.0


### PR DESCRIPTION
# Overview

A recent change was just pushed to Homebrew Cask fonts where the ref to FiraMono is now actually `FiraMono` rather than `FuraMono`.