### PR TITLE
chore: remove Alfred

### DIFF
--- a/config/Brewfile
+++ b/config/Brewfile
@@ -12,7 +12,6 @@ brew "rbenv"
 brew "tmux"
 
 cask "1password"
-cask "alfred"
 cask "appcleaner"
 cask "docker"
 cask "firefox"


### PR DESCRIPTION
# Overview

I've switched back to using stock Spotlight on macOS, so no need for Alfred anymore in the bundle.