### PR TITLE
chore(kitty): hide macOS title

### DIFF
--- a/config/kitty.conf
+++ b/config/kitty.conf
@@ -7,3 +7,5 @@ font_family FiraMono Nerd Font
 font_size 13.0
 
 adjust_line_height 112%
+
+macos_show_window_title_in none


### PR DESCRIPTION
# Overview

As the title states, this hides the window title in macOS for `kitty`.