### PR TITLE
fix(install): guard against non-existent Ghostty config directory

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -28,6 +28,8 @@ chsh -s /opt/homebrew/bin/bash
 
 # Ghostty config.
 ghostty_config_dir=~/Library/Application\ Support/com.mitchellh.ghostty
+mkdir -p "$ghostty_config_dir"
+[ ! -f "$ghostty_config_dir/config" ] && touch "$ghostty_config_dir/config"
 rm -f "$ghostty_config_dir/config" && ln -s "$dev_dir/dotfiles/config/ghostty_config" "$ghostty_config_dir/config"
 
 # Install Node and Ruby.


### PR DESCRIPTION
# Overview

After trying this on a couple different machines, some additional guards were needed to make sure the install script doesn't fail when configuring Ghostty.