### PR TITLE
fix(keybinds): toggle terminal

### DIFF
--- a/config/ghostty_config
+++ b/config/ghostty_config
@@ -23,4 +23,4 @@ keybind = alt+u=scroll_page_up
 keybind = alt+d=scroll_page_down
 
 # Misc
-keybind = global:command+k=toggle_quick_terminal
+keybind = global:command+shift+k=toggle_quick_terminal


### PR DESCRIPTION
# Overview

`command+k` was a little too disruptive as a lot of other applications use that keybind. This changes the terminal toggle to `command+shift+k` instead.