### PR TITLE
chore(Brewfile): replace Firefox with Zen Browser

### DIFF
--- a/config/Brewfile
+++ b/config/Brewfile
@@ -12,6 +12,6 @@ brew "rbenv"
 
 cask "1password"
 cask "appcleaner"
-cask "firefox"
 cask "ghostty"
 cask "orbstack"
+cask "zen-browser"


### PR DESCRIPTION
# Overview

Mozilla recently removed a clause from their terms that promised to never sell user data. Migrating to Zen Browser.